### PR TITLE
Keycloak image for amd64 and arm64 archs

### DIFF
--- a/keycloak/keycloak-deploy.yaml
+++ b/keycloak/keycloak-deploy.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: keycloak
-          image: quay.io/keycloak/keycloak:15.0.2
+          image: quay.io/kuadrant/authorino-examples:keycloak-15.0.2
           env:
             - name: KEYCLOAK_USER
               value: admin


### PR DESCRIPTION
Replaces the default Keycloak image (built only for amd64 arch) with a manifest image listing builds for amd64 and arm64