### PR TITLE
News API

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,44 @@ Just another echo API that responds as JSON whatever attributes it gets in the o
   </tbody>
 </table>
 
+### News API
+
+The News Agency API ("News API" for short) is a REST API with embedded concept of authentication or authorization. Whenever a request hits the API and it is a valid endpoint/operation, it serves the request. If it is a `POST` request to `/{category}`, it creates a news article under that news category. Creating an object here means storing it in memory. There is no persisted database. If it is a GET request to `/{category}`, it  serves the list of news articles in the category, as stored in memory. If it is a `GET` or `DELETE` to `/{category/(article-id}` it serves or deletes the requested object from memory, respectively.
+
+HTTP endpoints available:
+```
+POST /{category}          Create a news article
+GET /{category}           List news articles
+GET /{category}/{id}      Read a news article
+DELETE /{category}/{id}   Delete a news article
+```
+
+A news article is structured as follows:
+
+```jsonc
+{
+  "id": <string: auto-generated>,
+  "title": <string>,
+  "body": <string>,
+  "date": <string: ISO 8601>,
+  "author": <string>,
+  "user_id": <string>
+}
+```
+
+In the requests to `POST /{category}`, `author` and `user_id` can be supplied in either of 2 supported HTTP headers:
+- `X-Ext-Auth-Data`: stringified JSON containing at least the `author` and the `user_id` properties;
+- `X-Ext-Auth-Wristband`: an Authorino [Festival Wrisband](https://github.com/Kuadrant/authorino/blob/main/docs/features.md#festival-wristband-tokens-responsewristband) token whose `name` and `sub` claims map respectively to `author` and the `user_id`.
+
+<table>
+ <tbody>
+    <tr>
+      <th>Image:</th>
+      <td><a href="https://quay.io/kuadrant/authorino-examples:news-api"><code>quay.io/kuadrant/authorino-examples:news-api</code></a></td>
+    </tr>
+  </tbody>
+</table>
+
 ### Envoy
 
 Kubernetes manifests to deploy Envoy proxy – `ConfigMap`, `Deployment`, `Service` and `Ingress`.

--- a/news-api/.dockerignore
+++ b/news-api/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+*.yaml

--- a/news-api/Dockerfile
+++ b/news-api/Dockerfile
@@ -1,0 +1,16 @@
+FROM ruby:2.7
+
+RUN bundle config --global frozen 1
+
+WORKDIR /usr/src/app
+
+ENV PORT=8080 \
+    ENVIRONMENT=production
+
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+
+COPY . .
+
+ENTRYPOINT [ "sh", "-c" ]
+CMD ["exec rackup --port $PORT --env $ENVIRONMENT"]

--- a/news-api/Gemfile
+++ b/news-api/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'rack'

--- a/news-api/Gemfile.lock
+++ b/news-api/Gemfile.lock
@@ -1,0 +1,13 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rack (2.2.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rack
+
+BUNDLED WITH
+   2.1.4

--- a/news-api/config.ru
+++ b/news-api/config.ru
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+require 'logger'
+require 'json'
+require 'securerandom'
+require 'base64'
+
+Object.include(Module.new do
+  def try(method, *args)
+    send(method, *args) if respond_to?(method)
+  end
+end)
+
+Hash.include(Module.new do
+  def symbolize_keys
+    transform_keys{ |key| key.to_sym rescue key }
+  end
+
+  def reverse_merge(other_hash)
+    other_hash.merge(self)
+  end
+end)
+
+class Storage
+  def initialize
+    @news = {}
+  end
+
+  def list(category)
+    @news[category]&.values || []
+  end
+
+  def add(category, article)
+    @news[category] ||= {}
+    @news[category][article.id] = article
+  end
+
+  def get(category, article_id)
+    @news.dig(category, article_id)
+  end
+
+  def delete(category, article_id)
+    @news[category]&.delete(article_id)
+  end
+
+  def exists?(article_id)
+    @news.values.flat_map(&:keys).include?(article_id)
+  end
+end
+
+ATTRIBUTES = %i[title body date author user_id].freeze
+
+class Article < Struct.new(:id, *ATTRIBUTES, keyword_init: true)
+  def self.create(**params)
+    new(**params.merge(id: SecureRandom.uuid))
+  end
+
+  def to_json
+    to_h.to_json
+  end
+end
+
+class RackApp
+  def initialize
+    @storage = Storage.new
+    @logger = Logger.new(STDOUT)
+    @logger.level = ENV['LOG_LEVEL'] || 'info'
+  end
+
+  attr_reader :storage, :logger
+
+  def call(env)
+    request = Rack::Request.new(env)
+
+    request_method = request.request_method
+    request_path = request.path
+    request_query_string = request.query_string
+    request_query_string = nil if request_query_string.empty?
+
+    _, category, article_id = request_path.split('/')
+
+    extra_headers = {}
+    extra_headers.merge!('X-Ext-Auth-Data' => env[X_AUTH_DATA_HEADER]) if env[X_AUTH_DATA_HEADER]
+    extra_headers.merge!('X-Ext-Auth-Wristband' => env[X_AUTH_WRISTBAND_HEADER]) if env[X_AUTH_WRISTBAND_HEADER]
+
+    response = case request_method
+               when 'GET'
+                 if article_id.to_s.empty?
+                  respond_with(storage.list(category).map(&:to_h), extra_headers: extra_headers)
+                else
+                  respond_with(storage.get(category, article_id), extra_headers: extra_headers)
+                 end
+               when 'POST'
+                 params = JSON.parse(request.body.read).symbolize_keys.slice(*ATTRIBUTES)
+                 date = Time.now
+                 author, user_id = parse_auth_data(env)
+                 article = loop do # prevents duplicate article id
+                   article = Article.create(params.merge(date: date, author: author, user_id: user_id))
+                   break article unless storage.exists?(article.id)
+                 end
+
+                 respond_with(storage.add(category, article), extra_headers: extra_headers)
+               when 'DELETE'
+                 respond_with(storage.delete(category, article_id), extra_headers: extra_headers)
+               else
+                 render :not_found
+               end
+  rescue StandardError => e
+    response = render(e.try(:status) || :server_error, body: e.message)
+  ensure
+    logger.info "#{request_method} #{[request_path, request_query_string].compact.join('?')} => #{response.first}"
+  end
+
+  protected
+
+  X_AUTH_DATA_HEADER = 'HTTP_X_EXT_AUTH_DATA'
+  X_AUTH_WRISTBAND_HEADER = 'HTTP_X_EXT_AUTH_WRISTBAND'
+
+  def json_response(body)
+    [{'Content-Type' => 'application/json'}, [body.to_json]]
+  end
+
+  def render_ok(body)
+    [200, *json_response(body)]
+  end
+
+  def render_not_found(*)
+    [404, *json_response(error: 'Not found')]
+  end
+
+  def render_server_error(message)
+    [500, *json_response(error: message)]
+  end
+
+  def render(status, body: nil)
+    send("render_#{status}", body)
+  end
+
+  def respond_with(object, extra_headers: {})
+    return render(:not_found) unless object
+    status, headers, body = render(:ok, body: object)
+    [status, headers.merge(extra_headers), body]
+  end
+
+  def parse_auth_data(env)
+    x_auth_data = env[X_AUTH_DATA_HEADER]
+    x_auth_data = nil if x_auth_data == 'null'
+
+    if x_auth_data
+      auth_data = JSON.parse(x_auth_data)
+      return auth_data.values_at('author', 'user_id')
+    end
+
+    wristband_token = env[X_AUTH_WRISTBAND_HEADER]
+    wristband_token = nil if wristband_token == 'null'
+
+    if wristband_token
+      wristband_payload = JSON.parse(Base64.decode64(wristband_token.split('.')[1]))
+      return wristband_payload.values_at('name', 'sub')
+    end
+
+    ['Unknown', nil]
+  rescue JSON::ParserError => e
+    logger.debug "Failed to parse auth data: #{e}"
+    ['Unknown', nil]
+  end
+end
+
+run(RackApp.new)

--- a/news-api/news-api-deploy.yaml
+++ b/news-api/news-api-deploy.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: news-api
+  labels:
+    app: news-api
+spec:
+  selector:
+    matchLabels:
+      app: news-api
+  template:
+    metadata:
+      labels:
+        app: news-api
+    spec:
+      containers:
+      - name: news-api
+        image: quay.io/kuadrant/authorino-examples:news-api
+        imagePullPolicy: Always
+        env:
+        - name: PORT
+          value: "3000"
+        tty: true
+        ports:
+        - containerPort: 3000
+  replicas: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: news-api
+  labels:
+    app: news-api
+spec:
+  selector:
+    app: news-api
+  ports:
+  - name: http
+    port: 3000
+    protocol: TCP


### PR DESCRIPTION
The News Agency API ("News API" for short) is a REST API with embedded concept of authentication or authorization. Whenever a request hits the API and it is a valid endpoint/operation, it serves the request. If it is a `POST` request to `/{category}`, it creates a news article under that news category. Creating an object here means storing it in memory. There is no persisted database. If it is a GET request to `/{category}`, it  serves the list of news articles in the category, as stored in memory. If it is a `GET` or `DELETE` to `/{category/(article-id}` it serves or deletes the requested object from memory, respectively.

HTTP endpoints available:
```
POST /{category}          Create a news article
GET /{category}           List news articles
GET /{category}/{id}      Read a news article
DELETE /{category}/{id}   Delete a news article
```

A news article is structured as follows:

```jsonc
{
  "id": <string: auto-generated>,
  "title": <string>,
  "body": <string>,
  "date": <string: ISO 8601>,
  "author": <string>,
  "user_id": <string>
}
```

In the requests to `POST /{category}`, `author` and `user_id` can be supplied in either of 2 supported HTTP headers:
- `X-Ext-Auth-Data`: stringified JSON containing at least the `author` and the `user_id` properties;
- `X-Ext-Auth-Wristband`: an Authorino [Festival Wrisband](https://github.com/Kuadrant/authorino/blob/main/docs/features.md#festival-wristband-tokens-responsewristband) token whose `name` and `sub` claims map respectively to `author` and the `user_id`.