### PR TITLE
Envoy enhancements

### DIFF
--- a/envoy/envoy-notls-deploy.yaml
+++ b/envoy/envoy-notls-deploy.yaml
@@ -2,11 +2,93 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app: authorino
+    app: envoy
   name: envoy
 data:
   envoy.yaml: |
     static_resources:
+      clusters:
+      - name: authorino
+        connect_timeout: 0.25s
+        type: STRICT_DNS
+        lb_policy: ROUND_ROBIN
+        http2_protocol_options: {}
+        load_assignment:
+          cluster_name: authorino
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: authorino-authorino-authorization
+                    port_value: 50051
+      - name: limitador
+        connect_timeout: 1s
+        type: STRICT_DNS
+        lb_policy: ROUND_ROBIN
+        http2_protocol_options: {}
+        load_assignment:
+          cluster_name: limitador
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: limitador
+                    port_value: 8081
+      - name: talker-api
+        connect_timeout: 0.25s
+        type: STRICT_DNS
+        lb_policy: ROUND_ROBIN
+        load_assignment:
+          cluster_name: talker-api
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: talker-api
+                    port_value: 3000
+      - name: talker-web
+        connect_timeout: 0.25s
+        type: STRICT_DNS
+        lb_policy: ROUND_ROBIN
+        load_assignment:
+          cluster_name: talker-web
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: talker-web
+                    port_value: 8888
+      - name: opentelemetry
+        connect_timeout: 0.25s
+        type: STRICT_DNS
+        lb_policy: ROUND_ROBIN
+        http2_protocol_options: {}
+        load_assignment:
+          cluster_name: opentelemetry
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: otel-collector
+                    port_value: 4317
+      - name: jaeger
+        connect_timeout: 0.25s
+        type: STRICT_DNS
+        lb_policy: ROUND_ROBIN
+        load_assignment:
+          cluster_name: jaeger
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: jaeger
+                    port_value: 9411
       listeners:
       - address:
           socket_address:
@@ -18,6 +100,7 @@ data:
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
               stat_prefix: local
+              use_remote_address: true
               route_config:
                 name: local_route
                 virtual_hosts:
@@ -52,7 +135,7 @@ data:
                   include_peer_certificate: true
                   grpc_service:
                     envoy_grpc:
-                      cluster_name: external_auth
+                      cluster_name: authorino
                     timeout: 1s
               - name: envoy.filters.http.ratelimit
                 typed_config:
@@ -64,65 +147,32 @@ data:
                     transport_api_version: V3
                     grpc_service:
                       envoy_grpc:
-                        cluster_name: rate_limit
+                        cluster_name: limitador
               - name: envoy.filters.http.router
-                typed_config: {}
-              use_remote_address: true
-      clusters:
-      - name: external_auth
-        connect_timeout: 0.25s
-        type: strict_dns
-        lb_policy: round_robin
-        http2_protocol_options: {}
-        load_assignment:
-          cluster_name: external_auth
-          endpoints:
-          - lb_endpoints:
-            - endpoint:
-                address:
-                  socket_address:
-                    address: authorino-authorino-authorization
-                    port_value: 50051
-      - name: rate_limit
-        connect_timeout: 1s
-        type: STRICT_DNS
-        lb_policy: round_robin
-        http2_protocol_options: {}
-        load_assignment:
-          cluster_name: rale_limit
-          endpoints:
-          - lb_endpoints:
-            - endpoint:
-                address:
-                  socket_address:
-                    address: limitador
-                    port_value: 8081
-      - name: talker-api
-        connect_timeout: 0.25s
-        type: strict_dns
-        lb_policy: round_robin
-        load_assignment:
-          cluster_name: talker-api
-          endpoints:
-          - lb_endpoints:
-            - endpoint:
-                address:
-                  socket_address:
-                    address: talker-api
-                    port_value: 3000
-      - name: talker-web
-        connect_timeout: 0.25s
-        type: strict_dns
-        lb_policy: round_robin
-        load_assignment:
-          cluster_name: talker-web
-          endpoints:
-          - lb_endpoints:
-            - endpoint:
-                address:
-                  socket_address:
-                    address: talker-web
-                    port_value: 8888
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+              # # Uncomment the lines below to enable tracing
+              # # Choose either OpenTelemetry OTLP (gRPC) or Zipkin/Jaeger (HTTP), and uncomment the correspoding config
+              # tracing:
+              #   provider:
+              #     # #------------ OpenTelemetry OTLP (gRPC) ------------
+              #     # name: envoy.tracers.opentelemetry
+              #     # typed_config:
+              #     #   "@type": type.googleapis.com/envoy.config.trace.v3.OpenTelemetryConfig
+              #     #   grpc_service:
+              #     #     envoy_grpc:
+              #     #       cluster_name: opentelemetry
+              #     #     timeout: 1s
+              #     #   service_name: envoy
+              #     # #-------------- Zipkin/Jaeger (HTTP) --------------
+              #     # name: envoy.tracers.zipkin
+              #     # typed_config:
+              #     #   "@type": type.googleapis.com/envoy.config.trace.v3.ZipkinConfig
+              #     #   collector_cluster: jaeger
+              #     #   collector_endpoint: "/api/v2/spans"
+              #     #   shared_span_context: false
+              #     #   collector_endpoint_version: HTTP_JSON
     admin:
       access_log_path: "/tmp/admin_access.log"
       address:
@@ -134,20 +184,17 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: authorino
-    svc: envoy
+    app: envoy
   name: envoy
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: authorino
-      svc: envoy
+      app: envoy
   template:
     metadata:
       labels:
-        app: authorino
-        svc: envoy
+        app: envoy
     spec:
       containers:
       - args:
@@ -157,7 +204,7 @@ spec:
         - --component-log-level filter:trace,http:debug,router:debug
         command:
         - /usr/local/bin/envoy
-        image: envoyproxy/envoy:v1.19-latest
+        image: envoyproxy/envoy:v1.25-latest
         name: envoy
         ports:
         - containerPort: 8000
@@ -180,7 +227,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: authorino
+    app: envoy
   name: envoy
 spec:
   ports:
@@ -188,8 +235,7 @@ spec:
     port: 8000
     protocol: TCP
   selector:
-    app: authorino
-    svc: envoy
+    app: envoy
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/envoy/envoy-tls-deploy.yaml
+++ b/envoy/envoy-tls-deploy.yaml
@@ -2,11 +2,101 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app: authorino
+    app: envoy
   name: envoy
 data:
   envoy.yaml: |
     static_resources:
+      clusters:
+      - name: authorino
+        connect_timeout: 0.25s
+        type: STRICT_DNS
+        lb_policy: ROUND_ROBIN
+        http2_protocol_options: {}
+        load_assignment:
+          cluster_name: authorino
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: authorino-authorino-authorization
+                    port_value: 50051
+        transport_socket:
+          name: envoy.transport_sockets.tls
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+            common_tls_context:
+              validation_context:
+                trusted_ca:
+                  filename: /etc/ssl/certs/authorino-ca-cert.crt
+      - name: limitador
+        connect_timeout: 1s
+        type: STRICT_DNS
+        lb_policy: ROUND_ROBIN
+        http2_protocol_options: {}
+        load_assignment:
+          cluster_name: limitador
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: limitador
+                    port_value: 8081
+      - name: talker-api
+        connect_timeout: 0.25s
+        type: STRICT_DNS
+        lb_policy: ROUND_ROBIN
+        load_assignment:
+          cluster_name: talker-api
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: talker-api
+                    port_value: 3000
+      - name: talker-web
+        connect_timeout: 0.25s
+        type: STRICT_DNS
+        lb_policy: ROUND_ROBIN
+        load_assignment:
+          cluster_name: talker-web
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: talker-web
+                    port_value: 8888
+      - name: opentelemetry
+        connect_timeout: 0.25s
+        type: STRICT_DNS
+        lb_policy: ROUND_ROBIN
+        http2_protocol_options: {}
+        load_assignment:
+          cluster_name: opentelemetry
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: otel-collector
+                    port_value: 4317
+      - name: jaeger
+        connect_timeout: 0.25s
+        type: STRICT_DNS
+        lb_policy: ROUND_ROBIN
+        load_assignment:
+          cluster_name: jaeger
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: jaeger
+                    port_value: 9411
       listeners:
       - address:
           socket_address:
@@ -18,6 +108,7 @@ data:
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
               stat_prefix: local
+              use_remote_address: true
               route_config:
                 name: local_route
                 virtual_hosts:
@@ -52,7 +143,7 @@ data:
                   include_peer_certificate: true
                   grpc_service:
                     envoy_grpc:
-                      cluster_name: external_auth
+                      cluster_name: authorino
                     timeout: 1s
               - name: envoy.filters.http.ratelimit
                 typed_config:
@@ -64,73 +155,32 @@ data:
                     transport_api_version: V3
                     grpc_service:
                       envoy_grpc:
-                        cluster_name: rate_limit
+                        cluster_name: limitador
               - name: envoy.filters.http.router
-                typed_config: {}
-              use_remote_address: true
-      clusters:
-      - name: external_auth
-        connect_timeout: 0.25s
-        type: strict_dns
-        lb_policy: round_robin
-        http2_protocol_options: {}
-        load_assignment:
-          cluster_name: external_auth
-          endpoints:
-          - lb_endpoints:
-            - endpoint:
-                address:
-                  socket_address:
-                    address: authorino-authorino-authorization
-                    port_value: 50051
-        transport_socket:
-          name: envoy.transport_sockets.tls
-          typed_config:
-            "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-            common_tls_context:
-              validation_context:
-                trusted_ca:
-                  filename: /etc/ssl/certs/authorino-ca-cert.crt
-      - name: rate_limit
-        connect_timeout: 1s
-        type: STRICT_DNS
-        lb_policy: round_robin
-        http2_protocol_options: {}
-        load_assignment:
-          cluster_name: rale_limit
-          endpoints:
-          - lb_endpoints:
-            - endpoint:
-                address:
-                  socket_address:
-                    address: limitador
-                    port_value: 8081
-      - name: talker-api
-        connect_timeout: 0.25s
-        type: strict_dns
-        lb_policy: round_robin
-        load_assignment:
-          cluster_name: talker-api
-          endpoints:
-          - lb_endpoints:
-            - endpoint:
-                address:
-                  socket_address:
-                    address: talker-api
-                    port_value: 3000
-      - name: talker-web
-        connect_timeout: 0.25s
-        type: strict_dns
-        lb_policy: round_robin
-        load_assignment:
-          cluster_name: talker-web
-          endpoints:
-          - lb_endpoints:
-            - endpoint:
-                address:
-                  socket_address:
-                    address: talker-web
-                    port_value: 8888
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+              # # Uncomment the lines below to enable tracing
+              # # Choose either OpenTelemetry OTLP (gRPC) or Zipkin/Jaeger (HTTP), and uncomment the correspoding config
+              # tracing:
+              #   provider:
+              #     # #------------ OpenTelemetry OTLP (gRPC) ------------
+              #     # name: envoy.tracers.opentelemetry
+              #     # typed_config:
+              #     #   "@type": type.googleapis.com/envoy.config.trace.v3.OpenTelemetryConfig
+              #     #   grpc_service:
+              #     #     envoy_grpc:
+              #     #       cluster_name: opentelemetry
+              #     #     timeout: 1s
+              #     #   service_name: envoy
+              #     # #-------------- Zipkin/Jaeger (HTTP) --------------
+              #     # name: envoy.tracers.zipkin
+              #     # typed_config:
+              #     #   "@type": type.googleapis.com/envoy.config.trace.v3.ZipkinConfig
+              #     #   collector_cluster: jaeger
+              #     #   collector_endpoint: "/api/v2/spans"
+              #     #   shared_span_context: false
+              #     #   collector_endpoint_version: HTTP_JSON
     admin:
       access_log_path: "/tmp/admin_access.log"
       address:
@@ -142,20 +192,17 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: authorino
-    svc: envoy
+    app: envoy
   name: envoy
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: authorino
-      svc: envoy
+      app: envoy
   template:
     metadata:
       labels:
-        app: authorino
-        svc: envoy
+        app: envoy
     spec:
       containers:
       - args:
@@ -165,7 +212,7 @@ spec:
         - --component-log-level filter:trace,http:debug,router:debug
         command:
         - /usr/local/bin/envoy
-        image: envoyproxy/envoy:v1.19-latest
+        image: envoyproxy/envoy:v1.25-latest
         name: envoy
         ports:
         - containerPort: 8000
@@ -173,30 +220,30 @@ spec:
         - containerPort: 8001
           name: admin
         volumeMounts:
+        - mountPath: /usr/local/etc/envoy
+          name: config
+          readOnly: true
         - mountPath: /etc/ssl/certs/authorino-ca-cert.crt
           name: authorino-ca-cert
           readOnly: true
           subPath: ca.crt
-        - mountPath: /usr/local/etc/envoy
-          name: config
-          readOnly: true
       volumes:
-      - name: authorino-ca-cert
-        secret:
-          defaultMode: 420
-          secretName: authorino-ca-cert
       - configMap:
           items:
           - key: envoy.yaml
             path: envoy.yaml
           name: envoy
         name: config
+      - name: authorino-ca-cert
+        secret:
+          defaultMode: 420
+          secretName: authorino-ca-cert
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: authorino
+    app: envoy
   name: envoy
 spec:
   ports:
@@ -204,8 +251,7 @@ spec:
     port: 8000
     protocol: TCP
   selector:
-    app: authorino
-    svc: envoy
+    app: envoy
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/hello-world/envoy-deploy.yaml
+++ b/hello-world/envoy-deploy.yaml
@@ -2,11 +2,39 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app: authorino
+    app: envoy
   name: envoy
 data:
   envoy.yaml: |
     static_resources:
+      clusters:
+      - name: authorino
+        connect_timeout: 0.25s
+        type: STRICT_DNS
+        lb_policy: ROUND_ROBIN
+        http2_protocol_options: {}
+        load_assignment:
+          cluster_name: authorino
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: authorino-authorino-authorization.hello-world.svc.cluster.local
+                    port_value: 50051
+      - name: talker-api
+        connect_timeout: 0.25s
+        type: STRICT_DNS
+        lb_policy: ROUND_ROBIN
+        load_assignment:
+          cluster_name: talker-api
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: talker-api.hello-world.svc.cluster.local
+                    port_value: 3000
       listeners:
       - address:
           socket_address:
@@ -18,6 +46,7 @@ data:
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
               stat_prefix: local
+              use_remote_address: true
               route_config:
                 name: local_route
                 virtual_hosts:
@@ -42,39 +71,11 @@ data:
                   include_peer_certificate: true
                   grpc_service:
                     envoy_grpc:
-                      cluster_name: external_auth
+                      cluster_name: authorino
                     timeout: 1s
               - name: envoy.filters.http.router
-                typed_config: {}
-              use_remote_address: true
-      clusters:
-      - name: external_auth
-        connect_timeout: 0.25s
-        type: strict_dns
-        lb_policy: round_robin
-        http2_protocol_options: {}
-        load_assignment:
-          cluster_name: external_auth
-          endpoints:
-          - lb_endpoints:
-            - endpoint:
-                address:
-                  socket_address:
-                    address: authorino-authorino-authorization.hello-world.svc.cluster.local
-                    port_value: 50051
-      - name: talker-api
-        connect_timeout: 0.25s
-        type: strict_dns
-        lb_policy: round_robin
-        load_assignment:
-          cluster_name: talker-api
-          endpoints:
-          - lb_endpoints:
-            - endpoint:
-                address:
-                  socket_address:
-                    address: talker-api.hello-world.svc.cluster.local
-                    port_value: 3000
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
     admin:
       access_log_path: "/tmp/admin_access.log"
       address:
@@ -86,20 +87,17 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: authorino
-    svc: envoy
+    app: envoy
   name: envoy
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: authorino
-      svc: envoy
+      app: envoy
   template:
     metadata:
       labels:
-        app: authorino
-        svc: envoy
+        app: envoy
     spec:
       containers:
       - args:
@@ -109,7 +107,7 @@ spec:
         - --component-log-level filter:trace,http:debug,router:debug
         command:
         - /usr/local/bin/envoy
-        image: envoyproxy/envoy:v1.19-latest
+        image: envoyproxy/envoy:v1.25-latest
         name: envoy
         ports:
         - containerPort: 8000
@@ -132,7 +130,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: authorino
+    app: envoy
   name: envoy
 spec:
   ports:
@@ -140,5 +138,4 @@ spec:
     port: 8000
     protocol: TCP
   selector:
-    app: authorino
-    svc: envoy
+    app: envoy


### PR DESCRIPTION
- Bump Envoy to v1.25
- Add placeholders in the Envoy config to enable tracing ([Jaeger](https://www.jaegertracing.io) or [OpenTelemetry OTLP](https://opentelemetry.io/docs/collector/))