### PR TITLE
Tracing services enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Kubernetes manifests to deploy [**Limitador**](https://github.com/kuadrant/limit
 
 ### Tracing (OpenTelemetry and Jaeger)
 
-Kubernetes manifests to deploy [Jaeger](https://www.jaegertracing.io/) and [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) with the Jaeger exporter configured.
+Kubernetes manifests to deploy [Jaeger](https://www.jaegertracing.io/) and [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) (with the Jaeger exporter configured).
 
 <table>
  <tbody>
@@ -240,6 +240,7 @@ Kubernetes manifests to deploy [Jaeger](https://www.jaegertracing.io/) and [Open
       <td>
         <a href="https://hub.docker.com/r/jaegertracing/all-in-one/tags/?page=1&name=1.22"><code>jaegertracing/all-in-one:1.22</code></a><br/>
         <a href="https://hub.docker.com/r/otel/opentelemetry-collector/tags/?page=1&name=0.74.0"><code>otel/opentelemetry-collector:0.74.0</code></a>
+        <a href="https://hub.docker.com/r/otel/opentelemetry-collector-contrib/tags/?page=1&name=0.74.0"><code>otel/opentelemetry-collector-contrib:0.74.0</code></a>
       </td>
     </tr>
   </tbody>

--- a/envoy/envoy-notls-deploy.yaml
+++ b/envoy/envoy-notls-deploy.yaml
@@ -76,19 +76,6 @@ data:
                   socket_address:
                     address: otel-collector
                     port_value: 4317
-      - name: jaeger
-        connect_timeout: 0.25s
-        type: STRICT_DNS
-        lb_policy: ROUND_ROBIN
-        load_assignment:
-          cluster_name: jaeger
-          endpoints:
-          - lb_endpoints:
-            - endpoint:
-                address:
-                  socket_address:
-                    address: jaeger
-                    port_value: 9411
       listeners:
       - address:
           socket_address:
@@ -152,27 +139,17 @@ data:
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
-              # # Uncomment the lines below to enable tracing
-              # # Choose either OpenTelemetry OTLP (gRPC) or Zipkin/Jaeger (HTTP), and uncomment the correspoding config
+              # # Uncomment to enable tracing
               # tracing:
               #   provider:
-              #     # #------------ OpenTelemetry OTLP (gRPC) ------------
-              #     # name: envoy.tracers.opentelemetry
-              #     # typed_config:
-              #     #   "@type": type.googleapis.com/envoy.config.trace.v3.OpenTelemetryConfig
-              #     #   grpc_service:
-              #     #     envoy_grpc:
-              #     #       cluster_name: opentelemetry
-              #     #     timeout: 1s
-              #     #   service_name: envoy
-              #     # #-------------- Zipkin/Jaeger (HTTP) --------------
-              #     # name: envoy.tracers.zipkin
-              #     # typed_config:
-              #     #   "@type": type.googleapis.com/envoy.config.trace.v3.ZipkinConfig
-              #     #   collector_cluster: jaeger
-              #     #   collector_endpoint: "/api/v2/spans"
-              #     #   shared_span_context: false
-              #     #   collector_endpoint_version: HTTP_JSON
+              #     name: envoy.tracers.opentelemetry
+              #     typed_config:
+              #       "@type": type.googleapis.com/envoy.config.trace.v3.OpenTelemetryConfig
+              #       grpc_service:
+              #         envoy_grpc:
+              #           cluster_name: opentelemetry
+              #         timeout: 1s
+              #       service_name: envoy
     admin:
       access_log_path: "/tmp/admin_access.log"
       address:

--- a/envoy/envoy-tls-deploy.yaml
+++ b/envoy/envoy-tls-deploy.yaml
@@ -84,19 +84,6 @@ data:
                   socket_address:
                     address: otel-collector
                     port_value: 4317
-      - name: jaeger
-        connect_timeout: 0.25s
-        type: STRICT_DNS
-        lb_policy: ROUND_ROBIN
-        load_assignment:
-          cluster_name: jaeger
-          endpoints:
-          - lb_endpoints:
-            - endpoint:
-                address:
-                  socket_address:
-                    address: jaeger
-                    port_value: 9411
       listeners:
       - address:
           socket_address:
@@ -160,27 +147,17 @@ data:
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
-              # # Uncomment the lines below to enable tracing
-              # # Choose either OpenTelemetry OTLP (gRPC) or Zipkin/Jaeger (HTTP), and uncomment the correspoding config
+              # # Uncomment to enable tracing
               # tracing:
               #   provider:
-              #     # #------------ OpenTelemetry OTLP (gRPC) ------------
-              #     # name: envoy.tracers.opentelemetry
-              #     # typed_config:
-              #     #   "@type": type.googleapis.com/envoy.config.trace.v3.OpenTelemetryConfig
-              #     #   grpc_service:
-              #     #     envoy_grpc:
-              #     #       cluster_name: opentelemetry
-              #     #     timeout: 1s
-              #     #   service_name: envoy
-              #     # #-------------- Zipkin/Jaeger (HTTP) --------------
-              #     # name: envoy.tracers.zipkin
-              #     # typed_config:
-              #     #   "@type": type.googleapis.com/envoy.config.trace.v3.ZipkinConfig
-              #     #   collector_cluster: jaeger
-              #     #   collector_endpoint: "/api/v2/spans"
-              #     #   shared_span_context: false
-              #     #   collector_endpoint_version: HTTP_JSON
+              #     name: envoy.tracers.opentelemetry
+              #     typed_config:
+              #       "@type": type.googleapis.com/envoy.config.trace.v3.OpenTelemetryConfig
+              #       grpc_service:
+              #         envoy_grpc:
+              #           cluster_name: opentelemetry
+              #         timeout: 1s
+              #       service_name: envoy
     admin:
       access_log_path: "/tmp/admin_access.log"
       address:

--- a/tracing/jaeger.yaml
+++ b/tracing/jaeger.yaml
@@ -15,29 +15,36 @@ spec:
     spec:
       containers:
       - name: jaeger
-        image: jaegertracing/all-in-one:1.22
+        image: jaegertracing/all-in-one:1.43
         args:
-        - "--collector.zipkin.host-port=:9411"
+        - --collector.otlp.enabled=true
+        - --collector.otlp.grpc.host-port=:14251
+        - --collector.otlp.http.host-port=:9412
+        - --collector.zipkin.host-port=:9411
         ports:
-        - containerPort: 5775
-          name: zk-compact-trft
+        - name: zk-compact-trft
+          containerPort: 5775
           protocol: UDP
-        - containerPort: 6831
-          name: jg-compact-trft
+        - name: jg-compact-trft
+          containerPort: 6831
           protocol: UDP
-        - containerPort: 6832
-          name: jg-binary-trft
+        - name: jg-binary-trft
+          containerPort: 6832
           protocol: UDP
-        - containerPort: 5778
-          name: configs
-        - containerPort: 16686
-          name: server-frontend
-        - containerPort: 14250
-          name: collector-grpc
-        - containerPort: 14268
-          name: collector-trft
-        - containerPort: 9411
-          name: zk-collector
+        - name: configs
+          containerPort: 5778
+        - name: server-frontend
+          containerPort: 16686
+        - name: collector-grpc
+          containerPort: 14250
+        - name: collector-trft
+          containerPort: 14268
+        - name: otlp-grpc
+          containerPort: 14251
+        - name: otlp-http
+          containerPort: 9412
+        - name: zk-collector
+          containerPort: 9411
   replicas: 1
 ---
 apiVersion: v1
@@ -48,27 +55,33 @@ spec:
   selector:
     app: jaeger
   ports:
-  - port: 5775
-    name: zk-compact-trft
+  - name: zk-compact-trft
+    port: 5775
     protocol: UDP
-  - port: 6831
-    name: jg-compact-trft
+  - name: jg-compact-trft
+    port: 6831
     protocol: UDP
-  - port: 6832
-    name: jg-binary-trft
+  - name: jg-binary-trft
+    port: 6832
     protocol: UDP
-  - port: 5778
-    name: configs
+  - name: configs
+    port: 5778
     protocol: TCP
-  - port: 16686
-    name: server-frontend
+  - name: server-frontend
+    port: 16686
     protocol: TCP
-  - port: 14250
-    name: collector-grpc
+  - name: collector-grpc
+    port: 14250
     protocol: TCP
-  - port: 14268
-    name: collector-trft
+  - name: collector-trft
+    port: 14268
     protocol: TCP
-  - port: 9411
-    name: zk-collector
+  - name: otlp-grpc
+    port: 14251
+    protocol: TCP
+  - name: otlp-http
+    port: 9412
+    protocol: TCP
+  - name: zk-collector
+    port: 9411
     protocol: TCP

--- a/tracing/opentelemetry-collector-certs.yaml
+++ b/tracing/opentelemetry-collector-certs.yaml
@@ -1,0 +1,52 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app: otel
+  name: otel-ca-cert
+  namespace: $(NAMESPACE)
+spec:
+  commonName: '*.$(NAMESPACE).svc'
+  isCA: true
+  issuerRef:
+    kind: Issuer
+    name: otel-ca
+  secretName: otel-ca-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app: otel
+  name: otel-ca
+  namespace: $(NAMESPACE)
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app: otel
+  name: otel-server-cert
+  namespace: $(NAMESPACE)
+spec:
+  dnsNames:
+  - otel-collector
+  - otel-collector.$(NAMESPACE).svc
+  - otel-collector.$(NAMESPACE).svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: otel-cert-issuer
+  secretName: otel-server-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app: otel
+  name: otel-cert-issuer
+  namespace: $(NAMESPACE)
+spec:
+  ca:
+    secretName: otel-ca-cert

--- a/tracing/opentelemetry-collector-tls-basicauth.yaml
+++ b/tracing/opentelemetry-collector-tls-basicauth.yaml
@@ -1,0 +1,249 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-agent-conf
+  labels:
+    app: opentelemetry
+    component: otel-agent-conf
+data:
+  otel-agent-config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            tls:
+              cert_file: certs/tls.crt
+              key_file: certs/tls.key
+            auth:
+              authenticator: basicauth/server
+          http:
+            tls:
+              cert_file: certs/tls.crt
+              key_file: certs/tls.key
+            auth:
+              authenticator: basicauth/server
+    exporters:
+      otlp:
+        endpoint: "otel-collector:4317"
+        tls:
+          insecure: true
+        sending_queue:
+          num_consumers: 4
+          queue_size: 100
+        retry_on_failure:
+          enabled: true
+    processors:
+      batch:
+      memory_limiter:
+        # 80% of maximum memory up to 2G
+        limit_mib: 400
+        # 25% of limit up to 2G
+        spike_limit_mib: 100
+        check_interval: 5s
+    extensions:
+      zpages: {}
+      memory_ballast:
+        # Memory Ballast size should be max 1/3 to 1/2 of memory.
+        size_mib: 165
+      basicauth/server:
+        htpasswd:
+          inline: |
+            otel:secret
+    service:
+      extensions: [zpages, memory_ballast, "basicauth/server"]
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [memory_limiter, batch]
+          exporters: [otlp]
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: otel-agent
+  labels:
+    app: opentelemetry
+    component: otel-agent
+spec:
+  selector:
+    matchLabels:
+      app: opentelemetry
+      component: otel-agent
+  template:
+    metadata:
+      labels:
+        app: opentelemetry
+        component: otel-agent
+    spec:
+      containers:
+      - name: otel-agent
+        image: otel/opentelemetry-collector-contrib:0.74.0
+        command:
+          - "/otelcol-contrib"
+          - "--config=/conf/otel-agent-config.yaml"
+        resources:
+          limits:
+            cpu: 500m
+            memory: 500Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: 55679 # ZPages endpoint.
+        - containerPort: 4317 # Default OpenTelemetry receiver gRPC port.
+        - containerPort: 4318 # Default OpenTelemetry receiver HTTP port.
+        - containerPort: 8888  # Metrics.
+        volumeMounts:
+        - name: otel-agent-config-vol
+          mountPath: /conf
+        - name: otel-collector-server-cert
+          mountPath: /certs
+          readOnly: true
+      volumes:
+        - name: otel-agent-config-vol
+          configMap:
+            name: otel-agent-conf
+            items:
+            - key: otel-agent-config
+              path: otel-agent-config.yaml
+        - name: otel-collector-server-cert
+          secret:
+            defaultMode: 420
+            secretName: otel-server-cert
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-collector-conf
+  labels:
+    app: opentelemetry
+    component: otel-collector-conf
+data:
+  otel-collector-config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            tls:
+              cert_file: certs/tls.crt
+              key_file: certs/tls.key
+            auth:
+              authenticator: basicauth/server
+          http:
+            tls:
+              cert_file: certs/tls.crt
+              key_file: certs/tls.key
+            auth:
+              authenticator: basicauth/server
+    processors:
+      batch:
+      memory_limiter:
+        # 80% of maximum memory up to 2G
+        limit_mib: 1500
+        # 25% of limit up to 2G
+        spike_limit_mib: 512
+        check_interval: 5s
+    exporters:
+      jaeger:
+        endpoint: jaeger:14250
+        tls:
+          insecure: true
+    extensions:
+      zpages: {}
+      memory_ballast:
+        # Memory Ballast size should be max 1/3 to 1/2 of memory.
+        size_mib: 683
+      basicauth/server:
+        htpasswd:
+          inline: |
+            otel:secret
+    service:
+      extensions: ["zpages", "memory_ballast", "basicauth/server"]
+      pipelines:
+        traces/1:
+          receivers: [otlp]
+          processors: [memory_limiter, batch]
+          exporters: [jaeger]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-collector
+  labels:
+    app: opentelemetry
+    component: otel-collector
+spec:
+  ports:
+  - name: otlp-grpc # Default endpoint for OpenTelemetry gRPC receiver.
+    port: 4317
+    protocol: TCP
+    targetPort: 4317
+  - name: otlp-http # Default endpoint for OpenTelemetry HTTP receiver.
+    port: 4318
+    protocol: TCP
+    targetPort: 4318
+  - name: metrics # Default endpoint for querying metrics.
+    port: 8888
+  selector:
+    component: otel-collector
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-collector
+  labels:
+    app: opentelemetry
+    component: otel-collector
+spec:
+  selector:
+    matchLabels:
+      app: opentelemetry
+      component: otel-collector
+  minReadySeconds: 5
+  progressDeadlineSeconds: 120
+  replicas: 1 #TODO - adjust this to your own requirements
+  template:
+    metadata:
+      labels:
+        app: opentelemetry
+        component: otel-collector
+    spec:
+      containers:
+      - name: otel-collector
+        image: otel/opentelemetry-collector-contrib:0.74.0
+        command:
+          - "/otelcol-contrib"
+          - "--config=/conf/otel-collector-config.yaml"
+        resources:
+          limits:
+            cpu: 1
+            memory: 2Gi
+          requests:
+            cpu: 200m
+            memory: 400Mi
+        ports:
+        - containerPort: 55679 # Default endpoint for ZPages.
+        - containerPort: 4317 # Default endpoint for OpenTelemetry gRPC receiver.
+        - containerPort: 4318 # Default endpoint for OpenTelemetry HTTP receiver.
+        - containerPort: 14250 # Default endpoint for Jaeger gRPC receiver.
+        - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
+        - containerPort: 9411 # Default endpoint for Zipkin receiver.
+        - containerPort: 8888  # Default endpoint for querying metrics.
+        volumeMounts:
+        - name: otel-collector-config-vol
+          mountPath: /conf
+        - name: otel-collector-server-cert
+          mountPath: /certs
+          readOnly: true
+      volumes:
+        - name: otel-collector-config-vol
+          configMap:
+            name: otel-collector-conf
+            items:
+              - key: otel-collector-config
+                path: otel-collector-config.yaml
+        - name: otel-collector-server-cert
+          secret:
+            defaultMode: 420
+            secretName: otel-server-cert

--- a/tracing/opentelemetry-collector.yaml
+++ b/tracing/opentelemetry-collector.yaml
@@ -63,11 +63,11 @@ spec:
         component: otel-agent
     spec:
       containers:
-      - command:
+      - name: otel-agent
+        image: otel/opentelemetry-collector:0.74.0
+        command:
           - "/otelcol"
           - "--config=/conf/otel-agent-config.yaml"
-        image: otel/opentelemetry-collector:0.74.0
-        name: otel-agent
         resources:
           limits:
             cpu: 500m
@@ -77,18 +77,19 @@ spec:
             memory: 100Mi
         ports:
         - containerPort: 55679 # ZPages endpoint.
-        - containerPort: 4317 # Default OpenTelemetry receiver port.
+        - containerPort: 4317 # Default OpenTelemetry receiver gRPC port.
+        - containerPort: 4318 # Default OpenTelemetry receiver HTTP port.
         - containerPort: 8888  # Metrics.
         volumeMounts:
         - name: otel-agent-config-vol
           mountPath: /conf
       volumes:
-        - configMap:
+        - name: otel-agent-config-vol
+          configMap:
             name: otel-agent-conf
             items:
-              - key: otel-agent-config
-                path: otel-agent-config.yaml
-          name: otel-agent-config-vol
+            - key: otel-agent-config
+              path: otel-agent-config.yaml
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -174,11 +175,11 @@ spec:
         component: otel-collector
     spec:
       containers:
-      - command:
+      - name: otel-collector
+        image: otel/opentelemetry-collector:0.74.0
+        command:
           - "/otelcol"
           - "--config=/conf/otel-collector-config.yaml"
-        image: otel/opentelemetry-collector:0.74.0
-        name: otel-collector
         resources:
           limits:
             cpu: 1
@@ -188,7 +189,8 @@ spec:
             memory: 400Mi
         ports:
         - containerPort: 55679 # Default endpoint for ZPages.
-        - containerPort: 4317 # Default endpoint for OpenTelemetry receiver.
+        - containerPort: 4317 # Default endpoint for OpenTelemetry gRPC receiver.
+        - containerPort: 4318 # Default endpoint for OpenTelemetry HTTP receiver.
         - containerPort: 14250 # Default endpoint for Jaeger gRPC receiver.
         - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
         - containerPort: 9411 # Default endpoint for Zipkin receiver.
@@ -196,19 +198,10 @@ spec:
         volumeMounts:
         - name: otel-collector-config-vol
           mountPath: /conf
-#        - name: otel-collector-secrets
-#          mountPath: /secrets
       volumes:
-        - configMap:
+        - name: otel-collector-config-vol
+          configMap:
             name: otel-collector-conf
             items:
               - key: otel-collector-config
                 path: otel-collector-config.yaml
-          name: otel-collector-config-vol
-#        - secret:
-#            name: otel-collector-secrets
-#            items:
-#              - key: cert.pem
-#                path: cert.pem
-#              - key: key.pem
-#                path: key.pem


### PR DESCRIPTION
- [x] Bump Jaeger version to v1.43
- [x] Enable Jaeger OTLP collector (gRPC and HTTP) – with deprecation of Jaeger's HTTP (thrift) collector interface
- [x] Add version of OpenTelemetry Collector with TLS and HTTP Basic Auth enabled by default (otel/opentelemetry-collector-contrib)
- [x] Fix container and service ports