### PR TITLE
Update Keycloak

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The external authorization filter is disabled for the endpoints of the Talker We
 ### Keycloak
 
 A bundle with Kubernetes manifests to deploy a [**Keycloak**](https://www.keycloak.org) server, preloaded with the following realm setup:<br/>
-- Admin console: http://localhost:8080/auth/admin (admin/p)
+- Admin console: http://localhost:8080/admin (admin/p)
 - Preloaded realm: **kuadrant**
 - Preloaded clients:
   - **demo**: to which API consumers delegate access and therefore the one which access tokens are issued to
@@ -110,7 +110,7 @@ A bundle with Kubernetes manifests to deploy a [**Keycloak**](https://www.keyclo
  <tbody>
     <tr>
       <th>Image:</th>
-      <td><a href="quay.io/kuadrant/authorino-examples:keycloak-15.0.2"><code>quay.io/kuadrant/authorino-examples:keycloak-15.0.2</code></a></td>
+      <td><a href="quay.io/keycloak/keycloak:22.0"><code>quay.io/keycloak/keycloak:22.0</code></a></td>
     </tr>
   </tbody>
 </table>

--- a/keycloak/keycloak-deploy.yaml
+++ b/keycloak/keycloak-deploy.yaml
@@ -15,22 +15,23 @@ spec:
     spec:
       containers:
         - name: keycloak
-          image: quay.io/kuadrant/authorino-examples:keycloak-15.0.2
+          image: quay.io/keycloak/keycloak:22.0
+          args:
+            - start-dev
+            - --import-realm
           env:
-            - name: KEYCLOAK_USER
+            - name: KEYCLOAK_ADMIN
               value: admin
-            - name: KEYCLOAK_PASSWORD
+            - name: KEYCLOAK_ADMIN_PASSWORD
               value: p
-            - name: PROXY_ADDRESS_FORWARDING
-              value: "true"
-            - name: KEYCLOAK_IMPORT
-              value: /tmp/import-realm.json -Dkeycloak.profile.feature.upload_scripts=enabled
+            - name: KC_PROXY
+              value: edge
           ports:
             - name: auth
               containerPort: 8080
           volumeMounts:
             - name: realm
-              mountPath: /tmp/
+              mountPath: /opt/keycloak/data/import
               readOnly: true
       volumes:
         - name: realm


### PR DESCRIPTION
Update Keycloak to version 22.0.

The Authorino-maintained Keycloak container image is not longer needed, since now builds are available for both platforms of interest (amd64 and arm64.)