### PR TITLE
fix: hello world authconfig example

### DIFF
--- a/hello-world/authconfig.yaml
+++ b/hello-world/authconfig.yaml
@@ -1,16 +1,16 @@
-apiVersion: authorino.kuadrant.io/v1beta1
+apiVersion: authorino.kuadrant.io/v1beta3
 kind: AuthConfig
 metadata:
   name: talker-api-protection
 spec:
   hosts:
   - talker-api.127.0.0.1.nip.io
-  identity:
-  - name: api-clients
-    apiKey:
-      selector:
-        matchLabels:
-          group: friends
-    credentials:
-      in: authorization_header
-      keySelector: APIKEY
+  authentication:
+    "api-clients":
+      apiKey:
+        selector:
+          matchLabels:
+            group: friends
+      credentials:
+        authorizationHeader:
+          prefix: APIKEY


### PR DESCRIPTION
# Description
Closes: https://github.com/Kuadrant/authorino-examples/issues/38 https://github.com/Kuadrant/authorino-examples/issues/39

Update `AuthConfig` of the hello world example to `v1beta3`

# Verification
* Follow https://github.com/Kuadrant/authorino/blob/main/docs/user-guides/hello-world.md but at step 7, apply the `AuthConfig` from this PR:
```
kubectl -n hello-world apply -f https://raw.githubusercontent.com/KevFan/authorino-examples/refs/heads/update-hello-world/hello-world/authconfig.yaml
```
* User guide should work as described